### PR TITLE
Correct CSS syntax, attempting to preserve intent.

### DIFF
--- a/theme/assets/css/main.css
+++ b/theme/assets/css/main.css
@@ -1677,6 +1677,10 @@ form input[type="text"], form input[type="email"], form input[type="password"], 
         margin-top: 1em;
     }
 
+    #top2_bottom form input[type=text] {
+        margin-top: 0em;
+    }
+
     .button,
     button,
     input[type=button],
@@ -1685,12 +1689,6 @@ form input[type="text"], form input[type="email"], form input[type="password"], 
         margin-bottom: 15px;
     }
 }
-
-@media screen and (max-width: 1400px)
-#top2_bottom form input[type=text] {
-    margin-top: 0em;
-}
-
 
 #top {
     padding: 0px 0px !important;


### PR DESCRIPTION
There is one minor CSS syntax error, introduced in https://github.com/uklibraries/omeka-solr-shim/commit/e16aea21470b013bcfac7fd30cd690c50fe2d8a0 . Specifically, there are braces missing from a media query: https://github.com/uklibraries/omeka-solr-shim/blob/e16aea21470b013bcfac7fd30cd690c50fe2d8a0/theme/assets/css/main.css#L1649
I discussed this change in context with @libmanuk and we believe the intent is for `#top2_bottom form input[type=text]` but not the immediately following stanzas regarding `#top` or `.row` to be in scope.

Since there was a previous media query with the same parameter, I've merged the `#top2_bottom` stanza into the larger stanza and eliminated a duplicate media query.