### PR TITLE
Adhere to PSR-12 and add PHP_CodeSniffer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ docker exec -it exploreuk-web-app-omeka-1 /vendor/bin/phpunit /tests/integration
 /vendor/bin/phpunit /tests/integration
 ```
 
+Coding standard
+---------------
+
+This program attempts to adhere to the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding standard
+for all PHP code. For convenience, the dev environment
+provides [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/), which detects
+and can repair many PSR-12 violations.
+
+```bash
+# Detect PSR-12 violations.
+docker exec -it exploreuk-web-app-omeka-1 /vendor/bin/phpcs -w --exclude=Generic.Files.LineLength --standard=PSR12 /app/shim
+
+# Fix PSR-12 violations which can be fixed automatically.
+docker exec -it exploreuk-web-app-omeka-1 /vendor/bin/phpcbf -w --exclude=Generic.Files.LineLength --standard=PSR12 /app/shim
+```
+
 Licenses
 --------
 

--- a/app/shim/application/libraries/ExploreUK/ExploreUK.php
+++ b/app/shim/application/libraries/ExploreUK/ExploreUK.php
@@ -8,7 +8,7 @@ class ExploreUK
     private $omeka;
 
     public function __construct()
-	{
+    {
         $this->omeka = new OmekaShim();
         $this->config = [
             'base' => '',

--- a/app/shim/catalog.php
+++ b/app/shim/catalog.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once('application/libraries/ExploreUK/init.php');
 $app = new ExploreUK\ExploreUK();
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require-dev": {
         "rector/rector": "^2.1",
-        "phpunit/phpunit": "^12.3"
+        "phpunit/phpunit": "^12.3",
+        "squizlabs/php_codesniffer": "^4.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f92b24918f746167c81bbccd42ab824d",
+    "content-hash": "af3354b5037b09852a024bd4e01422a0",
     "packages": [],
     "packages-dev": [
         {
@@ -1696,6 +1696,85 @@
                 }
             ],
             "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "06113cfdaf117fc2165f9cd040bd0f17fcd5242d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/06113cfdaf117fc2165f9cd040bd0f17fcd5242d",
+                "reference": "06113cfdaf117fc2165f9cd040bd0f17fcd5242d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-15T11:28:58+00:00"
         },
         {
             "name": "staabm/side-effects-detector",


### PR DESCRIPTION
This adds PHP_CodeSniffer and adjusts current PHP code in app/shim to adhere to PSR-12.

The PSR-12 specification states that there must not be a hard limit on line length, so I have specifically added `--exclude=Generic.Files.LineLength` to the example options in documentation.

There are currently many files with lines above the *soft* limit of 120 characters, which are straightforward to list by dropping that `--exclude`.