### PR TITLE
add action to release a version to ghcr after CI passes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,8 @@ permissions:
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Should publish an image to https://github.com/uklibraries/exploreuk-web-app/pkgs/container/exploreuk-web-app. 
- The image takes its tag from the commit where it was produced.
- It should only run when the CI task completes (not when it fails). 
- Verified locally with [act]( https://github.com/nektos/act) and a vagrant VM.

fixes #56 