### PR TITLE
fixes #70, use bind mounts for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ app/theme
 /xml
 /secrets
 /vendor
-
+db.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,10 @@ services:
       - ./assets/frontpage-assets/files:/app/files
       # Bind mount for dev, baked in image for production
       - ./php-fpm/php.ini-development:/usr/local/etc/php/conf.d/php.ini
-      - omeka_static:/app
+      - ./app:/app
       - ./phpunit.xml:/phpunit.xml
     develop:
       watch:
-        - action: sync+restart
-          path: ./app
-          target: /app
-          ignore:
-            - node_modules/
         - action: sync+restart
           path: ./tests
           target: /tests
@@ -39,7 +34,7 @@ services:
     volumes:
       - ./assets/frontpage-assets/files:/app/files
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
-      - omeka_static:/app
+      - ./app:/app
       - findingaid:/opt/findingaid
     depends_on:
       - omeka
@@ -79,7 +74,6 @@ services:
 
 volumes:
   db_data:
-  omeka_static:
   findingaid:
 
 networks:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ find "$OMEKA_ROOT/files" -type d -exec chmod 0775 "{}" \;
 find "$OMEKA_ROOT/files" -type f -exec chmod 0664 "{}" \;
 
 if [ "$APP_ENV" == "development" ]; then
+    npm install
 	bash "$OMEKA_ROOT/exe/minify.sh"
 	set +e
 	/vendor/bin/phpcs -w --exclude=Generic.Files.LineLength --standard=PSR12 /tests /app/catalog.php /app/application/libraries/ExploreUK


### PR DESCRIPTION
Needed for PHP changes to update in development. Does not affect production.