### PR TITLE
Make .gitmodules protocol-agnostic.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "assets/frontpage-assets"]
 	path = assets/frontpage-assets
-	url = git@github.com:uklibraries/exploreuk-frontpage-assets.git
+	url = ../exploreuk-frontpage-assets.git


### PR DESCRIPTION
Fixed #90.

It's still implicitly tied to a specific platform, though.