### PR TITLE
use npm for scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ RUN npm install
 
 COPY ./app .
 
-# This will need to be reworked.
-RUN /app/exe/minify.sh
+RUN npm run minify-css
 
 FROM php:8.3-fpm-alpine AS development
 

--- a/app/exe/minify.sh
+++ b/app/exe/minify.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-APP_DIR="/app"
-dir="$APP_DIR/themes/omeukaprologue/assets/css"
-cd "$dir"
-npx lightningcss -o main.min.css -m main.css

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "lightningcss-cli": "^1.27.0"
+  },
+  "scripts": {
+    "minify-css": "cd themes/omeukaprologue/assets/css && lightningcss -o main.min.css -m main.css"
   }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ find "$OMEKA_ROOT/files" -type d -exec chmod 0775 "{}" \;
 find "$OMEKA_ROOT/files" -type f -exec chmod 0664 "{}" \;
 
 if [ "$APP_ENV" == "development" ]; then
-	bash "$OMEKA_ROOT/exe/minify.sh"
+	npm run --prefix "$OMEKA_ROOT" minify-css
 	set +e
 	/vendor/bin/phpcs -w --exclude=Generic.Files.LineLength --standard=PSR12 /tests /app/catalog.php /app/application/libraries/ExploreUK
 	/vendor/bin/phpunit --bootstrap /tests/bootstrap.php /tests


### PR DESCRIPTION
This PR replaces the minify.sh script with a short invocation of [lightningcss](https://lightningcss.dev/) using npm to ensure that our versions of packages will be ran consistently. 

fixes #92