### PR TITLE
110 extract simple pages

### DIFF
--- a/app/application/libraries/ExploreUK/views/about.php
+++ b/app/application/libraries/ExploreUK/views/about.php
@@ -1,0 +1,72 @@
+<?php
+    $m['page_title'] = 'About ExploreUK';
+    $m['current_page_title'] = $m['page_title'];
+    require('header.php');
+?>
+<main id="main-content">
+    <div class="slab slab--thin">
+        <div class="slab__wrapper">
+            <?php require('breadcrumbs.php'); ?>
+        </div>
+    </div>
+    <h1>About</h1>
+    <p>
+        ExploreUK is the gateway to many of
+        <a href="https://libraries.uky.edu/" target="_blank" rel="noopener">University of Kentucky Libraries</a>
+        rare and unique resources, particularly those housed in the
+        <a href="https://libraries.uky.edu/locations/special-collections-research-center" target="_blank" rel="noopener">Special Collections Research Center</a>.
+        ExploreUK provides free and public access to digital materials for research, teaching, and curious exploration.
+    </p>
+    <p>
+        Materials include manuscript collections, rare books, photographs, organizational records, newspapers, maps, architectural drawings, government publications, University of Kentucky archives, and more. The collections document the social, cultural, economic, and political history of the Commonwealth of Kentucky, but also include materials of national and international significance.
+    </p>
+    <h2>Content Types</h2>
+    <p>
+        When searching ExploreUK, you will discover the following content types:
+    </p>
+    <p>
+        Collection guides (also known as finding aids): These documents contain detailed information about a specific collection of papers or records and often include an inventory or box list. Use collection guides to determine if materials within a collection is relevant to your interests. When a collection has been digitized, the scans are embedded within the guide as well as discoverable individually through the ExploreUK search tool.
+    </p>
+    <p>
+        Digitized items: The Special Collections Research Center digitizes a portion of its rare and unique collections for online access. These scans can be accessed and downloaded through ExploreUK. Some digital content is described within collection guides (see above) while others are described by basic descriptive metadata. Users are responsible for securing appropriate permissions.
+    </p>
+    <p>
+        Born-digital items: In some cases, materials are created as digital formats, like .pdf, .jpeg, and .wav files. These are also available through ExploreUK. Like digitized items, they may be described within a collection guide or by basic descriptive metadata.
+    </p>
+    <h2>Platform and Tools</h2>
+    <p>
+        ExploreUK uses a combination of the following:
+    </p>
+    <ul>
+        <li>
+            Apache Solr
+        </li>
+        <li>
+            <a href="https://www.uky.edu/its/" target="_blank" rel="noopener">University of Kentucky Information Technology Services</a>
+            infrastructure for AIPs and DIPs storage
+        </li>
+        <li>
+            Collection guides and related information are managed by the
+            <a href="http://archivesspace.org/" target="_blank" rel="noopener">ArchivesSpace</a>
+            information management application.
+        </li>
+    </ul>
+    <p>Visit the
+        <a href="https://github.com/uklibraries" target="_blank" rel="noopener">UK Libraries GitHub page</a>
+        for more information.
+    </p>
+    <h2>Acknowledgements</h2>
+    <p>
+        A portion of the collection guides and digitized content on ExploreUK was made possible by support from the
+        <a href="https://www.clir.org/" target="_blank" rel="noopener">Council on Library and Information Resources</a>,
+        <a href="https://www.imls.gov/" target="_blank" rel="noopener">Institute of Museum and Library Services</a>,
+        <a href="https://www.heyburninitiative.org/" target="_blank" rel="noopener">The John G. Heyburn II Initiative for Excellence in the Federal Judiciary</a>, the
+        <a href="https://www.neh.gov/" target="_blank" rel="noopener">National Endowment for the Humanities</a>, and the
+        <a href="https://www.archives.gov/nhprc" target="_blank" rel="noopener">National Historical Publications &amp; Records Commission</a>.
+    </p>
+    <?php require('sponsors.php'); ?>
+</main>
+<?php
+    require('global-footer.html');
+    require('universal-footer.php');
+?>

--- a/app/application/libraries/ExploreUK/views/about.php
+++ b/app/application/libraries/ExploreUK/views/about.php
@@ -9,61 +9,65 @@
             <?php require('breadcrumbs.php'); ?>
         </div>
     </div>
-    <h1>About</h1>
-    <p>
-        ExploreUK is the gateway to many of
-        <a href="https://libraries.uky.edu/" target="_blank" rel="noopener">University of Kentucky Libraries</a>
-        rare and unique resources, particularly those housed in the
-        <a href="https://libraries.uky.edu/locations/special-collections-research-center" target="_blank" rel="noopener">Special Collections Research Center</a>.
-        ExploreUK provides free and public access to digital materials for research, teaching, and curious exploration.
-    </p>
-    <p>
-        Materials include manuscript collections, rare books, photographs, organizational records, newspapers, maps, architectural drawings, government publications, University of Kentucky archives, and more. The collections document the social, cultural, economic, and political history of the Commonwealth of Kentucky, but also include materials of national and international significance.
-    </p>
-    <h2>Content Types</h2>
-    <p>
-        When searching ExploreUK, you will discover the following content types:
-    </p>
-    <p>
-        Collection guides (also known as finding aids): These documents contain detailed information about a specific collection of papers or records and often include an inventory or box list. Use collection guides to determine if materials within a collection is relevant to your interests. When a collection has been digitized, the scans are embedded within the guide as well as discoverable individually through the ExploreUK search tool.
-    </p>
-    <p>
-        Digitized items: The Special Collections Research Center digitizes a portion of its rare and unique collections for online access. These scans can be accessed and downloaded through ExploreUK. Some digital content is described within collection guides (see above) while others are described by basic descriptive metadata. Users are responsible for securing appropriate permissions.
-    </p>
-    <p>
-        Born-digital items: In some cases, materials are created as digital formats, like .pdf, .jpeg, and .wav files. These are also available through ExploreUK. Like digitized items, they may be described within a collection guide or by basic descriptive metadata.
-    </p>
-    <h2>Platform and Tools</h2>
-    <p>
-        ExploreUK uses a combination of the following:
-    </p>
-    <ul>
-        <li>
-            Apache Solr
-        </li>
-        <li>
-            <a href="https://www.uky.edu/its/" target="_blank" rel="noopener">University of Kentucky Information Technology Services</a>
-            infrastructure for AIPs and DIPs storage
-        </li>
-        <li>
-            Collection guides and related information are managed by the
-            <a href="http://archivesspace.org/" target="_blank" rel="noopener">ArchivesSpace</a>
-            information management application.
-        </li>
-    </ul>
-    <p>Visit the
-        <a href="https://github.com/uklibraries" target="_blank" rel="noopener">UK Libraries GitHub page</a>
-        for more information.
-    </p>
-    <h2>Acknowledgements</h2>
-    <p>
-        A portion of the collection guides and digitized content on ExploreUK was made possible by support from the
-        <a href="https://www.clir.org/" target="_blank" rel="noopener">Council on Library and Information Resources</a>,
-        <a href="https://www.imls.gov/" target="_blank" rel="noopener">Institute of Museum and Library Services</a>,
-        <a href="https://www.heyburninitiative.org/" target="_blank" rel="noopener">The John G. Heyburn II Initiative for Excellence in the Federal Judiciary</a>, the
-        <a href="https://www.neh.gov/" target="_blank" rel="noopener">National Endowment for the Humanities</a>, and the
-        <a href="https://www.archives.gov/nhprc" target="_blank" rel="noopener">National Historical Publications &amp; Records Commission</a>.
-    </p>
+    <div class="slab">
+        <div class="slab__wrapper">
+            <h1>About</h1>
+            <p>
+                ExploreUK is the gateway to many of
+                <a href="https://libraries.uky.edu/" target="_blank" rel="noopener">University of Kentucky Libraries</a>
+                rare and unique resources, particularly those housed in the
+                <a href="https://libraries.uky.edu/locations/special-collections-research-center" target="_blank" rel="noopener">Special Collections Research Center</a>.
+                ExploreUK provides free and public access to digital materials for research, teaching, and curious exploration.
+            </p>
+            <p>
+                Materials include manuscript collections, rare books, photographs, organizational records, newspapers, maps, architectural drawings, government publications, University of Kentucky archives, and more. The collections document the social, cultural, economic, and political history of the Commonwealth of Kentucky, but also include materials of national and international significance.
+            </p>
+            <h2>Content Types</h2>
+            <p>
+                When searching ExploreUK, you will discover the following content types:
+            </p>
+            <p>
+                Collection guides (also known as finding aids): These documents contain detailed information about a specific collection of papers or records and often include an inventory or box list. Use collection guides to determine if materials within a collection is relevant to your interests. When a collection has been digitized, the scans are embedded within the guide as well as discoverable individually through the ExploreUK search tool.
+            </p>
+            <p>
+                Digitized items: The Special Collections Research Center digitizes a portion of its rare and unique collections for online access. These scans can be accessed and downloaded through ExploreUK. Some digital content is described within collection guides (see above) while others are described by basic descriptive metadata. Users are responsible for securing appropriate permissions.
+            </p>
+            <p>
+                Born-digital items: In some cases, materials are created as digital formats, like .pdf, .jpeg, and .wav files. These are also available through ExploreUK. Like digitized items, they may be described within a collection guide or by basic descriptive metadata.
+            </p>
+            <h2>Platform and Tools</h2>
+            <p>
+                ExploreUK uses a combination of the following:
+            </p>
+            <ul>
+                <li>
+                    Apache Solr
+                </li>
+                <li>
+                    <a href="https://www.uky.edu/its/" target="_blank" rel="noopener">University of Kentucky Information Technology Services</a>
+                    infrastructure for AIPs and DIPs storage
+                </li>
+                <li>
+                    Collection guides and related information are managed by the
+                    <a href="http://archivesspace.org/" target="_blank" rel="noopener">ArchivesSpace</a>
+                    information management application.
+                </li>
+            </ul>
+            <p>Visit the
+                <a href="https://github.com/uklibraries" target="_blank" rel="noopener">UK Libraries GitHub page</a>
+                for more information.
+            </p>
+            <h2>Acknowledgements</h2>
+            <p>
+                A portion of the collection guides and digitized content on ExploreUK was made possible by support from the
+                <a href="https://www.clir.org/" target="_blank" rel="noopener">Council on Library and Information Resources</a>,
+                <a href="https://www.imls.gov/" target="_blank" rel="noopener">Institute of Museum and Library Services</a>,
+                <a href="https://www.heyburninitiative.org/" target="_blank" rel="noopener">The John G. Heyburn II Initiative for Excellence in the Federal Judiciary</a>, the
+                <a href="https://www.neh.gov/" target="_blank" rel="noopener">National Endowment for the Humanities</a>, and the
+                <a href="https://www.archives.gov/nhprc" target="_blank" rel="noopener">National Historical Publications &amp; Records Commission</a>.
+            </p>
+        </div>
+    </div>
     <?php require('sponsors.php'); ?>
 </main>
 <?php

--- a/app/application/libraries/ExploreUK/views/simple-page.php
+++ b/app/application/libraries/ExploreUK/views/simple-page.php
@@ -1,4 +1,5 @@
-<?php require('header.php'); ?>
+<?php
+require('header.php'); ?>
 <?php $m['current_page_title'] = $m['page_title']; ?>
 <main id="main-content">
 <div class="slab slab--thin">

--- a/app/application/libraries/ExploreUK/views/takedown-policy.php
+++ b/app/application/libraries/ExploreUK/views/takedown-policy.php
@@ -1,0 +1,31 @@
+<?php
+    $m['page_title'] = 'Copyright, Use, and Take-Down Policies';
+    $m['current_page_title'] = $m['page_title'];
+    require('header.php');
+?>
+<main id="main-content">
+    <div class="slab slab--thin">
+        <div class="slab__wrapper">
+            <?php require('breadcrumbs.php'); ?>
+        </div>
+    </div>
+    <h1>Copyright, Use, and Take-Down Policies</h1>
+    <h2>Copyright and Use</h2>
+    <p>Disclaimer: The University of Kentucky Libraries Special Collections Research Center (SCRC) provides broad public access to collections as a contribution to education and scholarship. Most content in the digital libraries is protected by the U.S. Copyright Law (Title 17, U.S.C.). Use of the materials may also be subject to other legal rights, for example, rights of publicity, privacy rights, or other legal interests. Transmission or reproduction of materials protected by copyright beyond that allowed by fair use requires the written permission of the copyright owners. As noted, additional permissions may also be required. SCRC does not authorize any use or reproduction whatsoever for commercial purposes.</p>
+    <p>SCRC makes digital versions of collections accessible in the following situations: they are in the public domain; SCRC has permission to make them accessible online; materials are made accessible for education and research purposes as a legal fair use, or; there are no known restrictions on use.</p>
+    <p>Researchers should <a href="https://libraries.uky.edu/ContactSCRC" target="_blank" rel="noopener">contact SCRC</a> for additional information about rights, contacts, and permissions. Responsibility for making an independent legal assessment of an item and securing any necessary permissions ultimately rests with those persons wishing to use the item(s).</p>
+    <h2>Take-Down Policies</h2>
+    <p>The SCRC makes every effort to ensure that it has the appropriate rights to digitally preserve and provide access to its collections. Parties who have questions or concerns about the use of specific works may email the SCRC at scrc@uky.edu.</p>
+    <p>With all such communications, please include:</p>
+    <ul>
+        <li>A physical or electronic signature of the copyright owner. NOTE: If an agent is providing the notification, also include a statement that the agent is authorized to act on behalf of the owner.</li>
+        <li>Identification of the material that is claimed to be infringing or to be the subject of infringing activity and that is to be removed or access to which is to be disabled, and information reasonably sufficient to permit SCRC to locate the material. Providing URLs in your communication is the best way to help us locate content quickly.</li>
+        <li>The reason for the request.</li>
+    </ul>
+    <p>All correspondence will be answered within a reasonable time by SCRC.</p>
+    <?php require('sponsors.php'); ?>
+</main>
+<?php
+    require('global-footer.html');
+    require('universal-footer.php');
+?>

--- a/app/application/libraries/ExploreUK/views/takedown-policy.php
+++ b/app/application/libraries/ExploreUK/views/takedown-policy.php
@@ -9,20 +9,24 @@
             <?php require('breadcrumbs.php'); ?>
         </div>
     </div>
-    <h1>Copyright, Use, and Take-Down Policies</h1>
-    <h2>Copyright and Use</h2>
-    <p>Disclaimer: The University of Kentucky Libraries Special Collections Research Center (SCRC) provides broad public access to collections as a contribution to education and scholarship. Most content in the digital libraries is protected by the U.S. Copyright Law (Title 17, U.S.C.). Use of the materials may also be subject to other legal rights, for example, rights of publicity, privacy rights, or other legal interests. Transmission or reproduction of materials protected by copyright beyond that allowed by fair use requires the written permission of the copyright owners. As noted, additional permissions may also be required. SCRC does not authorize any use or reproduction whatsoever for commercial purposes.</p>
-    <p>SCRC makes digital versions of collections accessible in the following situations: they are in the public domain; SCRC has permission to make them accessible online; materials are made accessible for education and research purposes as a legal fair use, or; there are no known restrictions on use.</p>
-    <p>Researchers should <a href="https://libraries.uky.edu/ContactSCRC" target="_blank" rel="noopener">contact SCRC</a> for additional information about rights, contacts, and permissions. Responsibility for making an independent legal assessment of an item and securing any necessary permissions ultimately rests with those persons wishing to use the item(s).</p>
-    <h2>Take-Down Policies</h2>
-    <p>The SCRC makes every effort to ensure that it has the appropriate rights to digitally preserve and provide access to its collections. Parties who have questions or concerns about the use of specific works may email the SCRC at scrc@uky.edu.</p>
-    <p>With all such communications, please include:</p>
-    <ul>
-        <li>A physical or electronic signature of the copyright owner. NOTE: If an agent is providing the notification, also include a statement that the agent is authorized to act on behalf of the owner.</li>
-        <li>Identification of the material that is claimed to be infringing or to be the subject of infringing activity and that is to be removed or access to which is to be disabled, and information reasonably sufficient to permit SCRC to locate the material. Providing URLs in your communication is the best way to help us locate content quickly.</li>
-        <li>The reason for the request.</li>
-    </ul>
-    <p>All correspondence will be answered within a reasonable time by SCRC.</p>
+    <div class="slab">
+        <div class="slab__wrapper">
+            <h1>Copyright, Use, and Take-Down Policies</h1>
+            <h2>Copyright and Use</h2>
+            <p>Disclaimer: The University of Kentucky Libraries Special Collections Research Center (SCRC) provides broad public access to collections as a contribution to education and scholarship. Most content in the digital libraries is protected by the U.S. Copyright Law (Title 17, U.S.C.). Use of the materials may also be subject to other legal rights, for example, rights of publicity, privacy rights, or other legal interests. Transmission or reproduction of materials protected by copyright beyond that allowed by fair use requires the written permission of the copyright owners. As noted, additional permissions may also be required. SCRC does not authorize any use or reproduction whatsoever for commercial purposes.</p>
+            <p>SCRC makes digital versions of collections accessible in the following situations: they are in the public domain; SCRC has permission to make them accessible online; materials are made accessible for education and research purposes as a legal fair use, or; there are no known restrictions on use.</p>
+            <p>Researchers should <a href="https://libraries.uky.edu/ContactSCRC" target="_blank" rel="noopener">contact SCRC</a> for additional information about rights, contacts, and permissions. Responsibility for making an independent legal assessment of an item and securing any necessary permissions ultimately rests with those persons wishing to use the item(s).</p>
+            <h2>Take-Down Policies</h2>
+            <p>The SCRC makes every effort to ensure that it has the appropriate rights to digitally preserve and provide access to its collections. Parties who have questions or concerns about the use of specific works may email the SCRC at scrc@uky.edu.</p>
+            <p>With all such communications, please include:</p>
+            <ul>
+                <li>A physical or electronic signature of the copyright owner. NOTE: If an agent is providing the notification, also include a statement that the agent is authorized to act on behalf of the owner.</li>
+                <li>Identification of the material that is claimed to be infringing or to be the subject of infringing activity and that is to be removed or access to which is to be disabled, and information reasonably sufficient to permit SCRC to locate the material. Providing URLs in your communication is the best way to help us locate content quickly.</li>
+                <li>The reason for the request.</li>
+            </ul>
+            <p>All correspondence will be answered within a reasonable time by SCRC.</p>
+        </div>
+    </div>
     <?php require('sponsors.php'); ?>
 </main>
 <?php


### PR DESCRIPTION
This PR adds the simple pages from the omeka database as views. There are a few modifications to reflect the current state of the app, such as removal of the omeka mention in the about page.

This PR does not make the cut-over to use the pages. This is supposed to be purely data, but if you'd like to investigate the pages before the full integration, this could be temporarily added to line 02 in `simple-pages.php` to view this layout.

```php
    if (in_array($m['page']->slug, ['about', 'takedown-policy'])) {
        require __DIR__ . '/' . $m['page']->slug . '.php';
        return;
    }
```

fixes #110