### PR TITLE
73-improve-accessibility-of-link-rendering

### DIFF
--- a/app/application/libraries/ExploreUK/View.php
+++ b/app/application/libraries/ExploreUK/View.php
@@ -118,8 +118,6 @@ class View
                     $this->renderLink([
                         "href" => $this->path("/catalog/{$content['base_id']}"),
                         "content" => $collection_label,
-                        "external" => true,
-                        "open_new_tab" => true,
                     ]),
                     ' | ',
                     $this->renderLink([
@@ -211,20 +209,40 @@ class View
 
     public function renderLink($options)
     {
-        $content = $options["content"];
+        $external = !empty($options["external"]);
+        $open_new_tab = !empty($options["open_new_tab"]);
+        $content = htmlspecialchars((string) $options["content"], ENT_QUOTES);
         $attributes = [];
-        $attributes[] = "href=\"" . $options["href"] . "\"";
-        if (!empty($options["external"])) {
-            $content .= " <i class=\"fas fa-external-link-alt\"></i>";
+        $attributes[] = "href=\"" . htmlspecialchars((string) $options["href"], ENT_QUOTES) . "\"";
+        if ($external) {
+            $content .= " <span class=\"ic ic--popup\" aria-hidden=\"true\"></span>";
         }
-        if (!empty($options["open_new_tab"])) {
+        if ($open_new_tab) {
             # rel="noreferrer" implies target="_blank" and rel="noopener",
             # but I deliberately choose to include them explicitly.
             $attributes[] = "target=\"_blank\"";
             $attributes[] = "rel=\"noopener noreferrer\"";
         }
+        $note = $this->linkDestinationNote($external, $open_new_tab);
+        if ($note !== '') {
+            $content .= " <span class=\"show-for-sr\">($note)</span>";
+        }
         $attribute_string = implode(" ", $attributes);
-        return "<a class='underline-link' $attribute_string>$content</a>";
+        return "<a class=\"underline-link\" $attribute_string>$content</a>";
+    }
+
+    private function linkDestinationNote($external, $open_new_tab)
+    {
+        if ($external && $open_new_tab) {
+            return 'external link, opens in a new tab';
+        }
+        if ($external) {
+            return 'external link';
+        }
+        if ($open_new_tab) {
+            return 'opens in a new tab';
+        }
+        return '';
     }
 
     public function path($path)

--- a/app/application/libraries/ExploreUK/views/page-title.php
+++ b/app/application/libraries/ExploreUK/views/page-title.php
@@ -30,9 +30,9 @@
                         $dd = implode('', [
                             $content['value']['source_s'],
                             ' | ',
-                            $this->renderLink(['href' => $this->path("/catalog/{$content['value']['base_id']}"), 'content' => $collection_label, 'open_new_tab' => true]),
+                            $this->renderLink(['href' => $this->path("/catalog/{$content['value']['base_id']}"), 'content' => $collection_label]),
                             ' | ',
-                            $this->renderLink(['href' => $this->path($link . urlencode((string) $content['value']['source_s'])), 'content' => $link_label, 'open_new_tab' => true]),
+                            $this->renderLink(['href' => $this->path($link . urlencode((string) $content['value']['source_s'])), 'content' => $link_label]),
                         ]);
                         $rows .= '<dt>' . EUK_LOCALE['en']['source_s'] . '</dt><dd>' . $dd . "</dd>\n";
                     }

--- a/tests/unit/ViewTest.php
+++ b/tests/unit/ViewTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace ExploreUK;
+
+use PHPUnit\Framework\TestCase;
+
+final class ViewTest extends TestCase
+{
+    private View $view;
+
+    private const ICON = '<span class="ic ic--popup" aria-hidden="true"></span>';
+
+    protected function setUp(): void
+    {
+        $this->view = new View(['query' => null], 'about');
+    }
+
+    public function testPlainLinkGetsNoIconAndNoAnnouncement(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => '/catalog/xt123',
+            'content' => 'collection guide',
+        ]);
+
+        $this->assertSame(
+            '<a class="underline-link" href="/catalog/xt123">collection guide</a>',
+            $link
+        );
+    }
+
+    public function testNewTabIsAnnouncedWithoutAnExternalIcon(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => 'https://example.org',
+            'content' => 'Example',
+            'open_new_tab' => true,
+        ]);
+
+        $this->assertStringContainsString('<span class="show-for-sr">(opens in a new tab)</span>', $link);
+        $this->assertStringNotContainsString(self::ICON, $link);
+    }
+
+    public function testExternalIsAnnouncedAndIconIsHiddenFromAssistiveTech(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => '/catalog/xt123',
+            'content' => 'Example',
+            'external' => true,
+        ]);
+
+        $this->assertStringContainsString(self::ICON, $link);
+        $this->assertStringContainsString('<span class="show-for-sr">(external link)</span>', $link);
+        $this->assertStringNotContainsString('target="_blank"', $link);
+    }
+
+    public function testExternalNewTabAnnouncesBothIntents(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => 'https://example.org',
+            'content' => 'Example',
+            'external' => true,
+            'open_new_tab' => true,
+        ]);
+
+        $this->assertStringContainsString(self::ICON, $link);
+        $this->assertStringContainsString(
+            '<span class="show-for-sr">(external link, opens in a new tab)</span>',
+            $link
+        );
+    }
+
+    public function testOpenNewTabPairsTargetWithRel(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => 'https://example.org',
+            'content' => 'Example',
+            'open_new_tab' => true,
+        ]);
+
+        $this->assertStringContainsString('target="_blank"', $link);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $link);
+    }
+
+    public function testHrefCannotBreakOutOfItsAttribute(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => 'https://example.org/" onmouseover="alert(1)"',
+            'content' => 'Example',
+        ]);
+
+        $this->assertStringNotContainsString('onmouseover="alert(1)"', $link);
+        $this->assertStringContainsString('&quot; onmouseover=&quot;alert(1)', $link);
+    }
+
+    public function testContentIsEscaped(): void
+    {
+        $link = $this->view->renderLink([
+            'href' => '/catalog/xt123',
+            'content' => '<script>alert(1)</script>',
+        ]);
+
+        $this->assertStringNotContainsString('<script>', $link);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $link);
+    }
+}


### PR DESCRIPTION
Fixes #73; does not change hardcoded links throughout the templates, but modifies `renderLink` to make it an accessible path.

# Changes
- renderLink now includes a non-visible annoucement describing if the link opens in a new tab/window using [W3's G201 Technique](https://www.w3.org/WAI/WCAG22/Techniques/general/G201). This isn't a hard requirement, and developers should avoid opening new tabs per [W3's G200 Technique](https://www.w3.org/TR/WCAG20-TECHS/G200.html), but I'm sure in the rare case where opening a new tab makes sense, it will be helpful for users with assistive technology.
- The external indicator has a text equivalent in accordance with [WCAG 1.1.1](https://www.w3.org/TR/WCAG22/#non-text-content) and [WCAG 2.4.4](https://www.w3.org/TR/WCAG22/#link-purpose-in-context)
- Utilizes the renderLink when able. Exceptions were made for components shared with [findingaid](https://github.com/uklibraries/findingaid)